### PR TITLE
Use SIMD feature in rust regex crate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.0)
 project(RegexPeformance C CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(GENERAL_C_FLAGS "-Wall -Wstack-usage=2000 -Werror -fdiagnostics-color -pipe -fsigned-char -fno-asynchronous-unwind-tables -fno-stack-protector -Wunused-parameter")
+set(GENERAL_C_FLAGS "-march=native -Wall -Wstack-usage=2000 -Werror -fdiagnostics-color -pipe -fsigned-char -fno-asynchronous-unwind-tables -fno-stack-protector -Wunused-parameter")
 
 set(CMAKE_C_FLAGS "-std=c11 ${GENERAL_C_FLAGS}" CACHE STRING "additional CFLAGS" FORCE)
 set(CMAKE_C_FLAGS_DEBUG "-O0 -g")

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ The following regex engines are supported and covered by the tool:
 - [PCRE2](http://www.pcre.org)
 - [Rust regex crate](https://doc.rust-lang.org/regex/regex/index.html)
 
+The configuration script distinguishes between nightly and other Rust toolchains to enable the SIMD-feature
+which is currently available in the nightly built only. The SIMD-feature improves the throughput of the
+regex crate for defined expressions.
+
 ## Building the tool
 The different engines have different requirements which are not described here.
 Please see the related project documentations.

--- a/src/rust/.cargo/config.in
+++ b/src/rust/.cargo/config.in
@@ -1,2 +1,4 @@
 [build]
 target-dir = "@PROJECT_BINARY_DIR@/rregex"
+rustflags = ["-C","target-cpu=native"]
+

--- a/src/rust/CMakeLists.txt
+++ b/src/rust/CMakeLists.txt
@@ -1,22 +1,30 @@
 # check rust package manager
-find_program(RUST_CARGO cargo)
+find_program(RUST_C rustc)
 
-if(NOT RUST_CARGO)
-    message(FATAL_ERROR "Rust package manager 'cargo' not found.")
+if(NOT RUST_C)
+    message(FATAL_ERROR "Rust compiler 'rustc' not found.")
 else()
-    execute_process(COMMAND ${RUST_CARGO} --version OUTPUT_VARIABLE CARGO_VERSION)
-    string(STRIP ${CARGO_VERSION} CARGO_VERSION)
-    message("-- Found rust packet manager: ${CARGO_VERSION}")
+    execute_process(COMMAND ${RUST_C} --version OUTPUT_VARIABLE RUST_C_VERSION)
+    string(STRIP ${RUST_C_VERSION} RUST_C_VERSION)
+    message("-- Found rust compiler: ${RUST_C_VERSION}")
 endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/.cargo/config.in ${CMAKE_CURRENT_SOURCE_DIR}/.cargo/config)
 
 if(CMAKE_BUILD_TYPE MATCHES "^Release")
-    set(RUST_CARGO_RELEASE_OPT "--release")
+    list(APPEND CARGO_BUILD_OPT "--release")
+endif()
+
+if(${RUST_C_VERSION} MATCHES "nightly")
+    message("-- Found nightly. Use feature 'simd-accel': ON")
+
+    list(APPEND CARGO_BUILD_OPT "--features" "simd-accel")
+else()
+    message("-- Found stable. Use feature 'simd-accel': OFF")
 endif()
 
 add_custom_target(librregex ALL
     # create rust regex library
-    COMMAND ${RUST_CARGO} build ${RUST_CARGO_RELEASE_OPT}
+    COMMAND cargo build -v ${CARGO_BUILD_OPT}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -10,3 +10,7 @@ crate-type = ["staticlib"]
 [dependencies]
 regex = { version = "0.2.1"}
 libc = "0.2.19"
+
+[features]
+simd-accel = ["regex/simd-accel"]
+

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -1,12 +1,11 @@
 extern crate regex;
 extern crate libc;
 
-use regex::Regex;
+use regex::bytes::Regex;
 use libc::c_char;
 use std::boxed::Box;
 use std::ffi::CStr;
 use std::slice;
-use std::str;
 use std::ptr;
 
 #[no_mangle]
@@ -24,10 +23,7 @@ pub extern fn regex_new(c_buf: *const c_char) -> *const Regex {
 #[no_mangle]
 pub extern fn regex_matches(raw_exp: *mut Regex, p: *const u8, len: u64) -> u64 {
     let exp = unsafe { Box::from_raw(raw_exp) };
-    let s = unsafe { 
-        let slice = slice::from_raw_parts(p, len as usize);
-        str::from_utf8(slice).unwrap()
-    };
+    let s = unsafe { slice::from_raw_parts(p, len as usize) };
 
     let findings = exp.find_iter(s).count();
     Box::into_raw(exp);


### PR DESCRIPTION
The changes contain the improvements of the ticket https://github.com/rust-leipzig/regex-performance/issues/3.

- [x] Added support for SIMD feature depending on used toolchain.
- [x] Added README paragraph about used nightly features.
- [x] Added compile flags to build for native CPU target.
- [x] Improved Rust wrapper to use regex::bytes::Regex.