### PR TITLE
Added Yara

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ and the sljit project (See their regex comparison [here](http://sljit.sourceforg
 
 ## Supported engines
 The following regex engines are supported and covered by the tool:
+- [CTRE](https://github.com/hanickadot/compile-time-regular-expressions)
 - [Hyperscan](https://github.com/01org/hyperscan)
 - [Oniguruma](https://github.com/kkos/oniguruma)
 - [RE2](https://github.com/google/re2)
@@ -32,6 +33,7 @@ The following regex engines are supported and covered by the tool:
 - [PCRE2](http://www.pcre.org)
 - [Rust regex crate](https://doc.rust-lang.org/regex/regex/index.html)
 - [Regress regex crate](https://docs.rs/regress/)
+- [YARA](https://github.com/VirusTotal/yara)
 
 The engines are built from their sources. In the case an installed engine should be used,
 the corresponding cmake variable `INCLUDE_<name>` has to be set to `system`. The configuration script
@@ -82,6 +84,6 @@ You can specify a file to write the test results per expression and engine:
 ```
 The test tool writes the results in a csv-compatible format.
 
-## Results 
+## Results
 
 ![Shootout Performance Results](results_20220105.png "Performance Results")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,12 @@ if(NOT ${INCLUDE_BOOST} MATCHES "disabled")
     set(REGEX_ENGINES ${REGEX_ENGINES} boost_regex)
 endif()
 
+if(NOT ${INCLUDE_YARA} MATCHES "disabled")
+    add_definitions(-DINCLUDE_YARA)
+    set(REGEX_SOURCES ${REGEX_SOURCES} yara.c)
+    set(REGEX_ENGINES ${REGEX_ENGINES} yara)
+endif()
+
 include_directories(
     ${PROJECT_SOURCE_DIR}/vendor/local/include
     ${CMAKE_CURRENT_SOURCE_DIR}/rust/include

--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,9 @@ static struct engines engines [] = {
 #ifdef INCLUDE_HYPERSCAN
     {.name = "hscan",       .find_all = hs_find_all},
 #endif
+#ifdef INCLUDE_YARA
+    {.name = "yara",        .find_all = yara_find_all},
+#endif
     {.name = "rust_regex",  .find_all = rust_find_all},
     {.name = "rust_regrs",  .find_all = regress_find_all},
 };

--- a/src/main.h
+++ b/src/main.h
@@ -48,10 +48,12 @@ int onig_find_all(char* pattern, char* subject, int subject_len, int repeat, str
 #ifdef INCLUDE_HYPERSCAN
 int hs_find_all(char * pattern, char * subject, int subject_len, int repeat, struct result * res);
 #endif
+#ifdef INCLUDE_YARA
+int yara_find_all(char * pattern, char * subject, int subject_len, int repeat, struct result * res);
+#endif
 int rust_find_all(char * pattern, char * subject, int subject_len, int repeat, struct result * res);
 int regress_find_all(char * pattern, char * subject, int subject_len, int repeat, struct result * res);
 
 #ifdef __cplusplus
 }
 #endif
-

--- a/src/yara.c
+++ b/src/yara.c
@@ -1,0 +1,117 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <yara.h>
+
+#include "main.h"
+
+
+static int capture_matches(
+    YR_SCAN_CONTEXT* context,
+    int message,
+    void* message_data,
+    void* user_data)
+{
+  if (message == CALLBACK_MSG_RULE_MATCHING)
+  {
+    YR_RULE* rule = (YR_RULE*) message_data;
+    YR_STRING* string;
+
+    yr_rule_strings_foreach(rule, string)
+    {
+      YR_MATCH* match;
+
+      yr_string_matches_foreach(context, string, match)
+          (*(int*) user_data)++;
+    }
+  }
+
+  return 0;
+}
+
+char * return_rule_file(char* pattern)
+{
+  if (strcmp(pattern, "Twain") == 0)
+    return "../src/yara/ruleset/twain.yar";
+  else if (strcmp(pattern, "(?i)Twain") == 0)
+    return "../src/yara/ruleset/twain_i.yar";
+  else if (strcmp(pattern, "[a-z]shing") == 0)
+    return "../src/yara/ruleset/shing.yar";
+  else if (strcmp(pattern, "Huck[a-zA-Z]+|Saw[a-zA-Z]+") == 0)
+    return "../src/yara/ruleset/huck.yar";
+  else if (strcmp(pattern, "\\b\\w+nn\\b") == 0)
+    return "../src/yara/ruleset/word.yar";
+  else if (strcmp(pattern, "[a-q][^u-z]{13}x") == 0)
+    return "../src/yara/ruleset/aax.yar";
+  else if (strcmp(pattern, "Tom|Sawyer|Huckleberry|Finn") == 0)
+    return "../src/yara/ruleset/tom.yar";
+  else if (strcmp(pattern, "(?i)Tom|Sawyer|Huckleberry|Finn") == 0)
+    return "../src/yara/ruleset/tom_i.yar";
+  else if (strcmp(pattern, ".{0,2}(Tom|Sawyer|Huckleberry|Finn)") == 0)
+    return "../src/yara/ruleset/tom2.yar";
+  else if (strcmp(pattern, ".{2,4}(Tom|Sawyer|Huckleberry|Finn)") == 0)
+    return "../src/yara/ruleset/tom4.yar";
+  else if (strcmp(pattern, "Tom.{10,25}river|river.{10,25}Tom") == 0)
+    return "../src/yara/ruleset/tom10.yar";
+  else if (strcmp(pattern, "[a-zA-Z]+ing") == 0)
+    return "../src/yara/ruleset/ing+.yar";
+  else if (strcmp(pattern, "\\s[a-zA-Z]{0,12}ing\\s") == 0)
+    return "../src/yara/ruleset/ing.yar";
+  else if (strcmp(pattern, "([A-Za-z]awyer|[A-Za-z]inn)\\s") == 0)
+    return "../src/yara/ruleset/inn.yar";
+  else if (strcmp(pattern, "[\"'][^\"']{0,30}[?!\\.][\"']") == 0)
+    return "../src/yara/ruleset/mix.yar";
+  else if (strcmp(pattern, "\u221E|\u2713") == 0)
+    return "../src/yara/ruleset/inf.yar";
+  else
+    return "";
+}
+
+int yara_find_all(char* pattern, char* subject, int subject_len, int repeat, struct result* res)
+{
+  TIME_TYPE start, end = 0;
+  YR_COMPILER* compiler = NULL;
+  YR_RULES* rules = NULL;
+  int counter = 0;
+
+  char * rule_file = return_rule_file(pattern);
+
+  if (strlen(rule_file) == 0)
+  {
+    res->time = 999999;
+    res->time_sd = 0;
+    res->matches = 0;
+  }
+  else
+  {
+    FILE* fh = fopen(rule_file, "r");
+
+    yr_initialize();
+    yr_compiler_create(&compiler);
+    yr_compiler_add_file(compiler, fh, NULL, NULL);
+    yr_compiler_get_rules(compiler, &rules);
+
+    double * times = calloc(repeat, sizeof(double));
+    int const times_len = repeat;
+    do
+    {
+        counter = 0;
+        GET_TIME(start);
+        yr_rules_scan_mem(rules, (const uint8_t*) subject, subject_len, 0, capture_matches, &counter, 0);
+        GET_TIME(end);
+        times[repeat - 1] = TIME_DIFF_IN_MS(start, end);
+
+    } while (--repeat > 0);
+
+    yr_rules_destroy(rules);
+    yr_compiler_destroy(compiler);
+    fclose(fh);
+
+    res->matches = counter;
+    get_mean_and_derivation(times, times_len, res);
+
+    free(times);
+    yr_finalize();
+  }
+
+  return 0;
+}

--- a/src/yara/ruleset/aax.yar
+++ b/src/yara/ruleset/aax.yar
@@ -1,0 +1,7 @@
+rule aax
+{
+  strings:
+    $re = /[a-q][^u-z]{13}x/
+  condition:
+    $re
+}

--- a/src/yara/ruleset/huck.yar
+++ b/src/yara/ruleset/huck.yar
@@ -1,0 +1,7 @@
+rule huck
+{
+  strings:
+    $re = /Huck[a-zA-Z]+|Saw[a-zA-Z]+/
+  condition:
+    $re
+}

--- a/src/yara/ruleset/inf.yar
+++ b/src/yara/ruleset/inf.yar
@@ -1,0 +1,7 @@
+rule inf
+{
+  strings:
+    $re = /\xE2\x88\x9E|\xE2\x9C\x93/
+  condition:
+    $re
+}

--- a/src/yara/ruleset/ing+.yar
+++ b/src/yara/ruleset/ing+.yar
@@ -1,0 +1,7 @@
+rule ing
+{
+  strings:
+    $re = /[a-zA-Z]+ing/
+  condition:
+    $re
+}

--- a/src/yara/ruleset/ing.yar
+++ b/src/yara/ruleset/ing.yar
@@ -1,0 +1,7 @@
+rule ing
+{
+  strings:
+    $re = /\s[a-zA-Z]{0,12}ing\s/
+  condition:
+    $re
+}

--- a/src/yara/ruleset/inn.yar
+++ b/src/yara/ruleset/inn.yar
@@ -1,0 +1,7 @@
+rule inn
+{
+  strings:
+    $re = /([A-Za-z]awyer|[A-Za-z]inn)\s/
+  condition:
+    $re
+}

--- a/src/yara/ruleset/mix.yar
+++ b/src/yara/ruleset/mix.yar
@@ -1,0 +1,7 @@
+rule mix
+{
+  strings:
+    $re = /["'][^"']{0,30}[?!\.]["']/
+  condition:
+    $re
+}

--- a/src/yara/ruleset/shing.yar
+++ b/src/yara/ruleset/shing.yar
@@ -1,0 +1,7 @@
+rule shing
+{
+  strings:
+    $re = /[a-z]shing/
+  condition:
+    $re
+}

--- a/src/yara/ruleset/tom.yar
+++ b/src/yara/ruleset/tom.yar
@@ -1,0 +1,7 @@
+rule tom
+{
+  strings:
+    $re = /Tom|Sawyer|Huckleberry|Finn/
+  condition:
+    $re
+}

--- a/src/yara/ruleset/tom10.yar
+++ b/src/yara/ruleset/tom10.yar
@@ -1,0 +1,7 @@
+rule tom10
+{
+  strings:
+    $re = /Tom.{10,25}river|river.{10,25}Tom/
+  condition:
+    $re
+}

--- a/src/yara/ruleset/tom2.yar
+++ b/src/yara/ruleset/tom2.yar
@@ -1,0 +1,7 @@
+rule tom2
+{
+  strings:
+    $re = /.{0,2}(Tom|Sawyer|Huckleberry|Finn)/
+  condition:
+    $re
+}

--- a/src/yara/ruleset/tom4.yar
+++ b/src/yara/ruleset/tom4.yar
@@ -1,0 +1,7 @@
+rule tom4
+{
+  strings:
+    $re = /.{2,4}(Tom|Sawyer|Huckleberry|Finn)/
+  condition:
+    $re
+}

--- a/src/yara/ruleset/tom_i.yar
+++ b/src/yara/ruleset/tom_i.yar
@@ -1,0 +1,7 @@
+rule tome_nocase
+{
+  strings:
+    $re = /Tom|Sawyer|Huckleberry|Finn/ nocase
+  condition:
+    $re
+}

--- a/src/yara/ruleset/twain.yar
+++ b/src/yara/ruleset/twain.yar
@@ -1,0 +1,7 @@
+rule twain
+{
+  strings:
+    $str = "Twain"
+  condition:
+    $str
+}

--- a/src/yara/ruleset/twain_i.yar
+++ b/src/yara/ruleset/twain_i.yar
@@ -1,0 +1,7 @@
+rule twain_nocase
+{
+  strings:
+    $str = "Twain" nocase
+  condition:
+    $str
+}

--- a/src/yara/ruleset/word.yar
+++ b/src/yara/ruleset/word.yar
@@ -1,0 +1,7 @@
+rule word
+{
+  strings:
+    $re = /\b\w+nn\b/
+  condition:
+    $re
+}

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -122,13 +122,23 @@ set_property(CACHE INCLUDE_CPPSTD PROPERTY STRINGS "local" "system" "disabled")
 message("-- Include cppstd: ${INCLUDE_CPPSTD}")
 
 # ctre
-# 
+#
 AddExternalProject(
     "ctre"
     "ctre"
     "https://github.com/hanickadot/compile-time-regular-expressions.git"
     "master"
-    -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_SOURCE_DIR}/local 
+    -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_SOURCE_DIR}/local
+)
+
+# yara
+AddExternalProject(
+    "yara"
+    "yara"
+    "https://github.com/VirusTotal/yara.git"
+    "master"
+    cd ${CMAKE_CURRENT_SOURCE_DIR}/yara/ && ./bootstrap.sh && cd ${PROJECT_BINARY_DIR}/yara-build && ${CMAKE_CURRENT_SOURCE_DIR}/yara/configure --prefix=${CMAKE_CURRENT_SOURCE_DIR}/local
+
 )
 
 # boost - I'm not going to build boost here


### PR DESCRIPTION
I added Yara (https://github.com/VirusTotal/yara) for comparison. Yara uses a little bit different format of input (rules instead of just patterns). For that reason, I created a ruleset for tests.
The last two regular expressions are not supported at this moment in Yara, so they are skipped.
The PR is also adding links to Yara and CTRE as supported engines.